### PR TITLE
Moved webpack related deps to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,11 @@
   },
   "dependencies": {
     "bluebird": "^3.5.0",
-    "extract-text-webpack-plugin": "^2.1.0",
-    "tslib": "^1.6.0",
-    "webpack": "^2.2.1"
+    "tslib": "^1.6.0"
+  },
+  "peerDependencies": {
+    "webpack": ">= 2.2.1",
+    "extract-text-webpack-plugin": ">= 2.1.0"
   },
   "engines": {
     "node": ">=4.3.0 <5.0.0 || >=5.10"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-plugin-transform-promise-to-bluebird": "^1.1.1",
     "babel-preset-env": "^1.2.2",
     "css-loader": "^0.27.3",
+    "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.10.1",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-babel": "^6.1.2",


### PR DESCRIPTION
Use `webpack` and `extract-text-webpack-plugin` instances from top-level app instead of including them in the plugin itself. Fixes support for webpack 3.